### PR TITLE
Don't include CSS if user is logged out

### DIFF
--- a/hide-updates.php
+++ b/hide-updates.php
@@ -116,7 +116,7 @@ class HideUpdates {
 	 * Enqueue plugin stylesheet to hide elements for users not allowed to see WordPress updates.  
 	 */
 	function enqueue_plugin_styles() {
-		if ( !$this->allow_current_user() ) {
+		if ( is_user_logged_in() && !$this->allow_current_user() ) {
 			wp_enqueue_style( 'hide_updates_css', plugins_url( 'hide-updates.css', __FILE__ ) );
 		}
 	}


### PR DESCRIPTION
For some reason WordPress is returning a user from `wp_get_current_user()` even when the user is logged out. The user ID is set to 0. This makes `allow_current_user()` equal to false. This update checks if the user is logged in before enqueuing the CSS in the theme.